### PR TITLE
Update broken logo in nav

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Verida Datastore">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
-  <link rel="shortcut icon" https://uploads-ssl.webflow.com/60e8365cd5794f8db04151ed/6107868980521e0acf27b2d9_favicon.svg">
+  <link rel="shortcut icon" href=https://uploads-ssl.webflow.com/60e8365cd5794f8db04151ed/6107868980521e0acf27b2d9_favicon.svg">
 </head>
 <body>
   <div id="app"></div>
@@ -17,7 +17,7 @@
       loadSidebar: true,
       subMaxLevel: 2,
       repo: '',
-      "logo": "http://www.verida.io/img/logo.11449976.svg"
+      "logo": "href=https://uploads-ssl.webflow.com/60e8365cd5794f8db04151ed/6107868980521e0acf27b2d9_favicon.svg"
     }
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>


### PR DESCRIPTION
The  logo image href http://www.verida.io/img/logo.11449976.svg appears broken after launching new website